### PR TITLE
Add PostgreSQL support via compose override

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,13 @@
 GUACAMOLE_VERSION=1.6.0
 MYSQL_VERSION=8.0.44
+POSTGRES_VERSION=16.4-alpine
 NGINX_VERSION=1.21.1
 
 # Nginx related
 NGINX_HOST=guacamole.example.com
 NGINX_HTTP_PORT=80
+
+# Database related
+DB_USER=admin
+DB_PASSWORD=secret
+DB_NAME=guacamole

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+## OS generated files
+**/*~
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+*.bak
+.history
+
+docker-compose.override.yml
+*.log
+**/.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This is a Docker Compose stack that includes:
 ## Prerequisites
 
 * Docker 19.03.13 or latest
-* Docker compose 1.29.2 or latest
+* Docker compose v2.24.4 or latest
 
 ## How to Use
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
   - [Overview](#overview)
   - [Prerequisites](#prerequisites)
   - [How to Use](#how-to-use)
+    - [Start Guacamole](#start-guacamole)
+    - [Start Guacamole with Test Devices](#start-guacamole-with-test-devices)
+    - [Validation](#validation)
   - [Architecture](#architecture)
   - [Version Information](#version-information)
   - [Previous Releases](#previous-releases)
@@ -29,6 +32,15 @@ This is a Docker Compose stack that includes:
 ## How to Use
 
 ### Start Guacamole
+
+To use postgres instead of MySQL.
+
+```bash
+ln -sf postgres-override.yml docker-compose.override.yml
+```
+Ignore this step if you want to use MySQL.
+
+Note: `docker compose version` has to be greater than v2.24.4 for the override to work.
 
 To start Guacamole without the test devices (openssh, rdesktop):
 
@@ -68,6 +80,7 @@ The following versions are used in this setup:
 
 * Guacamole 1.6.0
 * MySQL 8.0.26
+* PosgreSQL 16.4-alpine
 * Nginx 1.21.1
 
 ## Previous Releases

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,9 @@ x-default: &default
     - 1.0.0.1
 
 x-dbenv:
-  - &dbUser admin
-  - &dbPass secret
-  - &dbDatabaseName guacamole
+  - &dbUser ${DB_USER}
+  - &dbPass ${DB_PASSWORD}
+  - &dbDatabaseName ${DB_NAME}
 
 networks:
   *networkName:
@@ -142,14 +142,14 @@ services:
       - devices
 
   # RDP Connection.
-  # The Default USERNAME and PASSWORD is: abc/abc
+  # RDP device. Username: ubuntu Password: ubuntu
   rdesktop:
     <<: *default
     environment:
       PUID: 1000
       PGID: 1000
       TZ: Asia/Kolkata
-    image: arulrajnet/rdesktop:ubuntu-xfce
+    image: danielguerra/ubuntu-xrdp:latest
     build:
       context: ./rdesktop
     networks:

--- a/postgres-override.yml
+++ b/postgres-override.yml
@@ -1,0 +1,44 @@
+x-dbenv:
+  - &dbUser ${DB_USER}
+  - &dbPass ${DB_PASSWORD}
+  - &dbDatabaseName ${DB_NAME}
+
+services:
+
+  db:
+    environment: !override
+      PGDATA: /data/postgres
+      POSTGRES_USER: *dbUser
+      POSTGRES_PASSWORD: *dbPass
+      POSTGRES_DB: *dbDatabaseName
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", *dbDatabaseName]
+      interval: 30s
+      timeout: 30s
+      retries: 3
+      start_period: 1m
+    image: postgres:${POSTGRES_VERSION}
+    ports:
+      - 5432
+    restart: on-failure
+    volumes:
+      - db-init:/docker-entrypoint-initdb.d:ro
+      - db-data:/data/postgres:rw
+
+  db-init:
+    command: ["/bin/sh", "-c", "test -e /init/initdb.sql && echo 'init file already exists' || /opt/guacamole/bin/initdb.sh --postgresql > /init/initdb.sql" ]
+    image: guacamole/guacamole:${GUACAMOLE_VERSION}
+    user: root
+    volumes:
+      - db-init:/init
+
+  guacamole:
+    environment: !override
+      JAVA_OPTS: -Xms1024m -Xmx2048m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -XX:+CrashOnOutOfMemoryError
+      GUACD_HOSTNAME: guacd
+      POSTGRESQL_HOSTNAME: db
+      POSTGRESQL_DATABASE: *dbDatabaseName
+      POSTGRESQL_USERNAME: *dbUser
+      POSTGRESQL_PASSWORD: *dbPass
+      # Set the log level for guacamole
+      LOGBACK_LEVEL: DEBUG


### PR DESCRIPTION
## Summary

- Add `postgres-override.yml` for running Guacamole with PostgreSQL 16.4 instead of MySQL
- Move hardcoded DB credentials (`admin`/`secret`/`guacamole`) to `.env` variables (`DB_USER`, `DB_PASSWORD`, `DB_NAME`)
- Add `.gitignore` to exclude common local files
- Update README to document the postgres override usage and compose version notes

## Usage

**PostgreSQL:**
```bash
docker compose -f docker-compose.yml -f postgres-override.yml up -d
```

**MySQL (default, unchanged):**
```bash
docker compose up -d
```

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation only
